### PR TITLE
Filter meal entries

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -51,7 +51,10 @@ object ApiClient {
                 val treatments = mutableListOf<Treatment>()
                 for (i in 0 until jsonArray.length()) {
                     val jsonObject = jsonArray.getJSONObject(i)
-                    treatments.add(Treatment.fromJson(jsonObject))
+                    val eventType = jsonObject.optString("eventType")
+                    if (eventType == "Meal Entry") {
+                        treatments.add(Treatment.fromJson(jsonObject))
+                    }
                 }
 
                 withContext(Dispatchers.Main) {


### PR DESCRIPTION
## Summary
- filter Nightscout treatments so that only "Meal Entry" events show in the list

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f19158008329b9cc9aeded8657ad