### PR TITLE
Add delete option for treatments

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -65,4 +65,24 @@ object ApiClient {
             }
         }
     }
+
+    fun deleteTreatment(id: String, callback: (Boolean) -> Unit) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val url = URL("$NIGHTSCOUT_URL/$id?token=$TOKEN")
+                val conn = url.openConnection() as HttpURLConnection
+                conn.requestMethod = "DELETE"
+
+                val success = conn.responseCode in 200..299
+                withContext(Dispatchers.Main) {
+                    callback(success)
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                withContext(Dispatchers.Main) {
+                    callback(false)
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -50,9 +50,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setupRecyclerView() {
-        adapter = TreatmentAdapter { treatment ->
-            showTreatmentDetails(treatment)
-        }
+        adapter = TreatmentAdapter(
+            onItemClick = { treatment -> showTreatmentDetails(treatment) },
+            onDelete = { treatment -> deleteTreatment(treatment) }
+        )
 
         binding.treatmentsRecyclerView.apply {
             layoutManager = LinearLayoutManager(this@MainActivity) // THIS WAS MISSING
@@ -88,5 +89,19 @@ class MainActivity : AppCompatActivity() {
 
     private fun showTreatmentDetails(treatment: Treatment) {
         Toast.makeText(this, "Selected: ${treatment.note}", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun deleteTreatment(treatment: Treatment) {
+        val id = treatment.id ?: return
+        ApiClient.deleteTreatment(id) { success ->
+            runOnUiThread {
+                if (success) {
+                    Toast.makeText(this, "Deleted", Toast.LENGTH_SHORT).show()
+                    loadTreatments()
+                } else {
+                    Toast.makeText(this, "Failed to delete", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/Treatment.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/Treatment.kt
@@ -9,7 +9,8 @@ data class Treatment(
     val protein: Float,
     val fat: Float,
     val note: String,
-    val timestamp: String = getUtcTimestamp()
+    val timestamp: String = getUtcTimestamp(),
+    val id: String? = null
 ) {
     fun toJson(): JSONObject {
         return JSONObject().apply {
@@ -36,7 +37,8 @@ data class Treatment(
                 protein = json.optDouble("protein", 0.0).toFloat(),
                 fat = json.optDouble("fat", 0.0).toFloat(),
                 note = json.optString("notes", ""),
-                timestamp = json.optString("created_at", "")
+                timestamp = json.optString("created_at", ""),
+                id = json.optString("_id", null)
             )
         }
     }

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentAdapter.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentAdapter.kt
@@ -11,7 +11,8 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 class TreatmentAdapter(
-    private val onItemClick: (Treatment) -> Unit = {} // Optional click listener
+    private val onItemClick: (Treatment) -> Unit = {}, // Optional click listener
+    private val onDelete: (Treatment) -> Unit = {}
 ) : RecyclerView.Adapter<TreatmentAdapter.ViewHolder>() {
 
     private val items = mutableListOf<Treatment>()
@@ -21,8 +22,14 @@ class TreatmentAdapter(
         val diffResult = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
             override fun getOldListSize() = items.size
             override fun getNewListSize() = newList.size
-            override fun areItemsTheSame(oldPos: Int, newPos: Int) =
-                items[oldPos].timestamp == newList[newPos].timestamp
+            override fun areItemsTheSame(oldPos: Int, newPos: Int): Boolean {
+                val oldItem = items[oldPos]
+                val newItem = newList[newPos]
+                return when {
+                    oldItem.id != null && newItem.id != null -> oldItem.id == newItem.id
+                    else -> oldItem.timestamp == newItem.timestamp
+                }
+            }
             override fun areContentsTheSame(oldPos: Int, newPos: Int) =
                 items[oldPos] == newList[newPos]
         })
@@ -37,6 +44,7 @@ class TreatmentAdapter(
         private val fatText: TextView = itemView.findViewById(R.id.fatText)
         private val noteText: TextView = itemView.findViewById(R.id.noteText)
         private val createdAtText: TextView = itemView.findViewById(R.id.createdAtText)
+        private val deleteButton: View = itemView.findViewById(R.id.deleteButton)
 
         fun bind(treatment: Treatment) {
             carbsText.text = itemView.context.getString(R.string.carbs_format, treatment.carbs)
@@ -46,6 +54,7 @@ class TreatmentAdapter(
             createdAtText.text = formatDate(treatment.timestamp)
 
             itemView.setOnClickListener { onItemClick(treatment) }
+            deleteButton.setOnClickListener { onDelete(treatment) }
         }
 
         private fun formatDate(isoDate: String): String {

--- a/app/src/main/res/layout/treatment_item.xml
+++ b/app/src/main/res/layout/treatment_item.xml
@@ -5,11 +5,24 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <TextView
-        android:id="@+id/createdAtText"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textStyle="bold"/>
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/createdAtText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textStyle="bold"/>
+
+        <Button
+            android:id="@+id/deleteButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/delete"/>
+    </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="carbs_format">Carbs: %.1fg</string>
     <string name="protein_format">Protein: %.1fg</string>
     <string name="fat_format">Fat: %.1fg</string>
+    <string name="delete">X</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow deleting treatments from Nightscout
- parse treatment `_id` from API
- expose a delete endpoint
- add delete button in treatment item layout
- hook delete button from adapter and activity

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872ec8ebb288329af99c8922a5f361b