### PR TITLE
Enable timestamp selection for treatments

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -1,8 +1,12 @@
 package com.atelierdjames.nillafood
 
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import java.text.SimpleDateFormat
+import java.util.*
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -12,11 +16,42 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private lateinit var adapter: TreatmentAdapter
     private val TAG = "MainActivity"
+    private val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    private val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        binding.timestampInput.setText(sdf.format(calendar.time))
+        binding.timestampInput.setOnClickListener {
+            DatePickerDialog(
+                this,
+                { _, year, month, dayOfMonth ->
+                    calendar.set(Calendar.YEAR, year)
+                    calendar.set(Calendar.MONTH, month)
+                    calendar.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+                    TimePickerDialog(
+                        this,
+                        { _, hour, minute ->
+                            calendar.set(Calendar.HOUR_OF_DAY, hour)
+                            calendar.set(Calendar.MINUTE, minute)
+                            calendar.set(Calendar.SECOND, 0)
+                            binding.timestampInput.setText(sdf.format(calendar.time))
+                        },
+                        calendar.get(Calendar.HOUR_OF_DAY),
+                        calendar.get(Calendar.MINUTE),
+                        true
+                    ).show()
+                },
+                calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH),
+                calendar.get(Calendar.DAY_OF_MONTH)
+            ).show()
+        }
 
         setupRecyclerView()
         loadTreatments()
@@ -32,7 +67,8 @@ class MainActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
-            val treatment = Treatment(carbs, protein, fat, note)
+            val timestamp = binding.timestampInput.text.toString()
+            val treatment = Treatment(carbs, protein, fat, note, timestamp)
             ApiClient.sendTreatment(this, treatment) { success ->
                 runOnUiThread {
                     if (success) {

--- a/app/src/main/java/com/atelierdjames/nillafood/Treatment.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/Treatment.kt
@@ -25,7 +25,7 @@ data class Treatment(
     }
 
     companion object {
-        private fun getUtcTimestamp(): String {
+        fun getUtcTimestamp(): String {
             val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
             sdf.timeZone = TimeZone.getTimeZone("UTC")
             return sdf.format(Date())

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -39,6 +39,15 @@
             android:layout_height="wrap_content"
             android:hint="Notes" />
 
+        <EditText
+            android:id="@+id/timestampInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/timestamp_hint"
+            android:focusable="false"
+            android:clickable="true"
+            android:inputType="none" />
+
         <Button
             android:id="@+id/submitButton"
             android:text="Log Meal"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="protein_format">Protein: %.1fg</string>
     <string name="fat_format">Fat: %.1fg</string>
     <string name="delete">X</string>
+    <string name="timestamp_hint">Date &amp; Time</string>
 </resources>


### PR DESCRIPTION
## Summary
- expose `getUtcTimestamp` so the current time can be reused
- allow a custom timestamp to be chosen in `MainActivity`
- add a timestamp field to the UI
- include a hint string for the new field

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737ffe6fa483299038091da1446b42