### PR TITLE
Implement average glucose feature

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -80,6 +80,7 @@ class MainActivity : AppCompatActivity() {
                         binding.mealsLayout.visibility = View.GONE
                         binding.insulinLayout.visibility = View.GONE
                         binding.nightscoutLayout.visibility = View.VISIBLE
+                        loadAverageGlucose()
                     }
                 }
             }
@@ -172,6 +173,18 @@ class MainActivity : AppCompatActivity() {
                     insulinAdapter.submitList(it)
                     updateLastScanText(it)
                 }
+            }
+        }
+    }
+
+    private fun loadAverageGlucose() {
+        binding.averageGlucose.text = getString(R.string.average_glucose_placeholder)
+        ApiClient.getAverageGlucose { avg ->
+            runOnUiThread {
+                val text = avg?.let { value ->
+                    if (!value.isNaN()) getString(R.string.average_glucose_format, value) else getString(R.string.average_glucose_placeholder)
+                } ?: getString(R.string.average_glucose_placeholder)
+                binding.averageGlucose.text = text
             }
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -137,6 +137,15 @@
         android:layout_weight="1"
         android:visibility="gone">
 
+        <TextView
+            android:id="@+id/averageGlucose"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/average_glucose_placeholder"
+            android:textAlignment="center"
+            android:textSize="16sp"
+            android:padding="8dp" />
+
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="tab_insulin">Insulin</string>
     <string name="tab_nightscout">Nightscout</string>
     <string name="last_scan_format">Last %1$s Pen Scan %2$d hours ago</string>
+    <string name="average_glucose_placeholder">Average glucose loading...</string>
+    <string name="average_glucose_format">24h Avg: %.1f mmol/L</string>
 </resources>


### PR DESCRIPTION
## Summary
- fetch 24h entries from Nightscout
- calculate mmol/L average
- show average glucose in the Nightscout tab

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873d026f5a08329b77a8da3b00cedc4