### PR TITLE
Add local glucose cache

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
@@ -1,0 +1,35 @@
+package com.atelierdjames.nillafood
+
+import android.content.Context
+
+object GlucoseStorage {
+    private const val PREFS = "glucose_store"
+    private const val KEY_ENTRIES = "entries"
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    fun getAllEntries(context: Context): List<Pair<String, Float>> {
+        val set = prefs(context).getStringSet(KEY_ENTRIES, emptySet()) ?: emptySet()
+        return set.mapNotNull { entry ->
+            val parts = entry.split("|")
+            val value = parts.getOrNull(1)?.toFloatOrNull()
+            val ts = parts.getOrNull(0)
+            if (ts != null && value != null) ts to value else null
+        }
+    }
+
+    fun addEntries(context: Context, entries: List<Pair<String, Float>>) {
+        if (entries.isEmpty()) return
+        val p = prefs(context)
+        val set = p.getStringSet(KEY_ENTRIES, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+        for (e in entries) {
+            set.add("${e.first}|${e.second}")
+        }
+        p.edit().putStringSet(KEY_ENTRIES, set).apply()
+    }
+
+    fun getLatestTimestamp(context: Context): String? {
+        return getAllEntries(context).maxByOrNull { it.first }?.first
+    }
+}

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -179,7 +179,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun loadAverageGlucose() {
         binding.averageGlucose.text = getString(R.string.average_glucose_placeholder)
-        ApiClient.getAverageGlucose { avg ->
+        ApiClient.getAverageGlucose(this) { avg ->
             runOnUiThread {
                 val text = avg?.let { value ->
                     if (!value.isNaN()) getString(R.string.average_glucose_format, value) else getString(R.string.average_glucose_placeholder)


### PR DESCRIPTION
## Summary
- store glucose entries locally using SharedPreferences
- sync new entries when calculating average glucose
- compute the last day's average from cached data
- update usage in `MainActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742e2c5c1483299dabe5b7e5ebc104