### PR TITLE
Add HbA1c and SD stats

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -270,13 +270,36 @@ object ApiClient {
                 )
             }
 
+            // Overall metrics using all stored values
+            var overallSum = 0f
+            var overallCount = 0
+            for ((_, v) in entries) {
+                overallSum += v
+                overallCount++
+            }
+            val overallAvgMgdl = if (overallCount > 0) overallSum / overallCount else Float.NaN
+            var variance = 0f
+            if (overallCount > 0) {
+                for ((_, v) in entries) {
+                    variance += (v - overallAvgMgdl) * (v - overallAvgMgdl)
+                }
+                variance /= overallCount
+            } else {
+                variance = Float.NaN
+            }
+            val sd = if (!variance.isNaN()) kotlin.math.sqrt(variance.toDouble()).toFloat() / 18f else Float.NaN
+            val hba1cPercent = if (!overallAvgMgdl.isNaN()) (overallAvgMgdl + 46.7f) / 28.7f else Float.NaN
+            val hba1cMmolMol = if (!hba1cPercent.isNaN()) hba1cPercent * 10.93f else Float.NaN
+
             val stats = GlucoseStats(
                 avg24h = avgFor(1),
                 avg7d = avgFor(7),
                 avg14d = avgFor(14),
                 tir24h = tirFor(1),
                 tir7d = tirFor(7),
-                tir14d = tirFor(14)
+                tir14d = tirFor(14),
+                hba1c = hba1cMmolMol,
+                sd = sd
             )
 
             withContext(Dispatchers.Main) { callback(stats) }

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseStats.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseStats.kt
@@ -12,5 +12,7 @@ data class GlucoseStats(
     val avg14d: Float,
     val tir24h: TimeInRange,
     val tir7d: TimeInRange,
-    val tir14d: TimeInRange
+    val tir14d: TimeInRange,
+    val hba1c: Float,
+    val sd: Float
 )

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -181,6 +181,8 @@ class MainActivity : AppCompatActivity() {
         binding.averageGlucose.text = getString(R.string.average_glucose_placeholder)
         binding.averageGlucose7.text = getString(R.string.average_glucose_placeholder)
         binding.averageGlucose14.text = getString(R.string.average_glucose_placeholder)
+        binding.hba1cText.text = getString(R.string.hba1c_placeholder)
+        binding.sdText.text = getString(R.string.sd_placeholder)
 
         ApiClient.getGlucoseStats(this) { result ->
             runOnUiThread {
@@ -189,6 +191,8 @@ class MainActivity : AppCompatActivity() {
                     binding.averageGlucose.text = if (!stats.avg24h.isNaN()) getString(R.string.average_glucose_format, stats.avg24h) else placeholder
                     binding.averageGlucose7.text = if (!stats.avg7d.isNaN()) getString(R.string.average_glucose_7d_format, stats.avg7d) else placeholder
                     binding.averageGlucose14.text = if (!stats.avg14d.isNaN()) getString(R.string.average_glucose_14d_format, stats.avg14d) else placeholder
+                    binding.hba1cText.text = if (!stats.hba1c.isNaN()) getString(R.string.hba1c_format, stats.hba1c) else getString(R.string.hba1c_placeholder)
+                    binding.sdText.text = if (!stats.sd.isNaN()) getString(R.string.sd_format, stats.sd) else getString(R.string.sd_placeholder)
                     setupPieChart(binding.pie24h, stats.tir24h)
                     setupPieChart(binding.pie7d, stats.tir7d)
                     setupPieChart(binding.pie14d, stats.tir14d)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -254,6 +254,24 @@
             android:padding="8dp" />
 
         <TextView
+            android:id="@+id/hba1cText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/hba1c_placeholder"
+            android:textAlignment="center"
+            android:textSize="16sp"
+            android:padding="8dp" />
+
+        <TextView
+            android:id="@+id/sdText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/sd_placeholder"
+            android:textAlignment="center"
+            android:textSize="16sp"
+            android:padding="8dp" />
+
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/time_in_range_24h"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,8 @@
     <string name="time_in_range_24h">Time in Range (24h)</string>
     <string name="time_in_range_7d">Time in Range (7d)</string>
     <string name="time_in_range_14d">Time in Range (14d)</string>
+    <string name="hba1c_placeholder">HbA1c loading...</string>
+    <string name="sd_placeholder">SD loading...</string>
+    <string name="hba1c_format">Est. HbA1c: %.1f mmol/mol</string>
+    <string name="sd_format">SD: %.1f mmol/L</string>
 </resources>


### PR DESCRIPTION
## Summary
- compute overall HbA1c and SD from cached glucose entries
- show new HbA1c and SD values on the stats screen

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d58facc48329923713f46fe51aa3