### PR TITLE
Add Room caching for treatments

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
@@ -3,7 +3,8 @@ package com.atelierdjames.nillafood
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [GlucoseEntry::class], version = 1)
+@Database(entities = [GlucoseEntry::class, TreatmentEntity::class], version = 2)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun glucoseDao(): GlucoseDao
+    abstract fun treatmentDao(): TreatmentDao
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/DatabaseProvider.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/DatabaseProvider.kt
@@ -1,0 +1,21 @@
+package com.atelierdjames.nillafood
+
+import android.content.Context
+import androidx.room.Room
+
+object DatabaseProvider {
+    private const val DB_NAME = "app-db"
+
+    @Volatile
+    private var INSTANCE: AppDatabase? = null
+
+    fun db(context: Context): AppDatabase {
+        return INSTANCE ?: synchronized(this) {
+            INSTANCE ?: Room.databaseBuilder(
+                context.applicationContext,
+                AppDatabase::class.java,
+                DB_NAME
+            ).fallbackToDestructiveMigration().build().also { INSTANCE = it }
+        }
+    }
+}

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
@@ -1,22 +1,10 @@
 package com.atelierdjames.nillafood
 
 import android.content.Context
-import androidx.room.Room
 
 object GlucoseStorage {
-    private const val DB_NAME = "app-db"
-
-    @Volatile
-    private var INSTANCE: AppDatabase? = null
-
     private fun db(context: Context): AppDatabase {
-        return INSTANCE ?: synchronized(this) {
-            INSTANCE ?: Room.databaseBuilder(
-                context.applicationContext,
-                AppDatabase::class.java,
-                DB_NAME
-            ).build().also { INSTANCE = it }
-        }
+        return DatabaseProvider.db(context)
     }
 
     suspend fun getAllEntries(context: Context): List<Pair<String, Float>> {

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -149,7 +149,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun loadTreatments() {
         Log.d(TAG, "Loading treatments...")
-        ApiClient.getRecentTreatments { result ->
+        ApiClient.getRecentTreatments(this) { result ->
             runOnUiThread {
                 result?.let { treatments ->
                     Log.d(TAG, "Received ${treatments.size} treatments")

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentDao.kt
@@ -1,0 +1,18 @@
+package com.atelierdjames.nillafood
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface TreatmentDao {
+    @Query("SELECT * FROM treatments ORDER BY timestamp DESC")
+    suspend fun getAll(): List<TreatmentEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(entries: List<TreatmentEntity>)
+
+    @Query("SELECT timestamp FROM treatments ORDER BY timestamp DESC LIMIT 1")
+    suspend fun getLatestTimestamp(): String?
+}

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentEntity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentEntity.kt
@@ -1,0 +1,23 @@
+package com.atelierdjames.nillafood
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "treatments")
+data class TreatmentEntity(
+    @PrimaryKey val id: String,
+    val carbs: Float,
+    val protein: Float,
+    val fat: Float,
+    val note: String,
+    val timestamp: String
+) {
+    fun toTreatment(): Treatment = Treatment(carbs, protein, fat, note, timestamp, id)
+
+    companion object {
+        fun from(treatment: Treatment): TreatmentEntity? {
+            val tid = treatment.id ?: return null
+            return TreatmentEntity(tid, treatment.carbs, treatment.protein, treatment.fat, treatment.note, treatment.timestamp)
+        }
+    }
+}

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentStorage.kt
@@ -1,0 +1,22 @@
+package com.atelierdjames.nillafood
+
+import android.content.Context
+
+object TreatmentStorage {
+    private fun db(context: Context) = DatabaseProvider.db(context)
+
+    suspend fun getAll(context: Context): List<Treatment> {
+        return db(context).treatmentDao().getAll().map { it.toTreatment() }
+    }
+
+    suspend fun addOrUpdate(context: Context, treatments: List<Treatment>) {
+        val entities = treatments.mapNotNull { TreatmentEntity.from(it) }
+        if (entities.isNotEmpty()) {
+            db(context).treatmentDao().insertAll(entities)
+        }
+    }
+
+    suspend fun getLatestTimestamp(context: Context): String? {
+        return db(context).treatmentDao().getLatestTimestamp()
+    }
+}


### PR DESCRIPTION
## Summary
- store treatments offline using Room database
- add `TreatmentEntity`/`TreatmentDao`/`TreatmentStorage`
- add `DatabaseProvider` for shared DB access
- upgrade `AppDatabase` to include treatment table
- sync new treatments from API and load from DB

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875053e97348329bc470a48246c85e0