### PR TITLE
Add details to glucose storage

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
@@ -3,7 +3,7 @@ package com.atelierdjames.nillafood
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [GlucoseEntry::class, TreatmentEntity::class], version = 2)
+@Database(entities = [GlucoseEntry::class, TreatmentEntity::class], version = 3)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun glucoseDao(): GlucoseDao
     abstract fun treatmentDao(): TreatmentDao

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseDao.kt
@@ -13,6 +13,6 @@ interface GlucoseDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(entries: List<GlucoseEntry>)
 
-    @Query("SELECT timestamp FROM glucose_entries ORDER BY timestamp DESC LIMIT 1")
-    suspend fun getLatestTimestamp(): String?
+    @Query("SELECT date FROM glucose_entries ORDER BY date DESC LIMIT 1")
+    suspend fun getLatestTimestamp(): Long?
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseEntry.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseEntry.kt
@@ -5,6 +5,10 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "glucose_entries")
 data class GlucoseEntry(
-    @PrimaryKey val timestamp: String,
-    val value: Float
+    @PrimaryKey val id: String,
+    val sgv: Float,
+    val direction: String?,
+    val device: String?,
+    val date: Long,
+    val noise: Int?
 )

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
@@ -7,17 +7,16 @@ object GlucoseStorage {
         return DatabaseProvider.db(context)
     }
 
-    suspend fun getAllEntries(context: Context): List<Pair<String, Float>> {
-        return db(context).glucoseDao().getAll().map { it.timestamp to it.value }
+    suspend fun getAllEntries(context: Context): List<GlucoseEntry> {
+        return db(context).glucoseDao().getAll()
     }
 
-    suspend fun addEntries(context: Context, entries: List<Pair<String, Float>>) {
+    suspend fun addEntries(context: Context, entries: List<GlucoseEntry>) {
         if (entries.isEmpty()) return
-        val list = entries.map { GlucoseEntry(it.first, it.second) }
-        db(context).glucoseDao().insertAll(list)
+        db(context).glucoseDao().insertAll(entries)
     }
 
-    suspend fun getLatestTimestamp(context: Context): String? {
+    suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).glucoseDao().getLatestTimestamp()
     }
 }


### PR DESCRIPTION
## Summary
- extend `GlucoseEntry` to store id, device, direction, date and noise
- persist these new fields in `GlucoseDao`/`GlucoseStorage`
- update API client to parse and store full entry objects
- bump database version to trigger a migration

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753a11a8e08329808fd663e0fff5fe