### PR TITLE
Store insulin injection id

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -107,6 +107,7 @@ object ApiClient {
                 for (i in 0 until jsonArray.length()) {
                     val obj = jsonArray.getJSONObject(i)
                     val time = obj.optString("created_at")
+                    val id = obj.optString("_id")
                     val injField = obj.opt("insulinInjections")
                     val injArray = when (injField) {
                         is JSONArray -> injField
@@ -116,14 +117,15 @@ object ApiClient {
                     if (injArray.length() == 0 && obj.has("insulin")) {
                         val units = obj.optDouble("insulin", 0.0).toFloat()
                         val name = obj.optString("insulinType", "")
-                        newInjections.add(InsulinInjection(time, name, units))
+                        newInjections.add(InsulinInjection(id, time, name, units))
                     }
 
                     for (j in 0 until injArray.length()) {
                         val inj = injArray.getJSONObject(j)
                         val name = inj.optString("insulin")
                         val units = inj.optDouble("units", 0.0).toFloat()
-                        newInjections.add(InsulinInjection(time, name, units))
+                        val uniqueId = "$id-$j"
+                        newInjections.add(InsulinInjection(uniqueId, time, name, units))
                     }
                 }
                 InsulinInjectionStorage.addAll(context, newInjections)

--- a/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 
 @Database(
     entities = [GlucoseEntry::class, TreatmentEntity::class, InsulinInjectionEntity::class],
-    version = 4
+    version = 5
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun glucoseDao(): GlucoseDao

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjection.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjection.kt
@@ -1,6 +1,7 @@
 package com.atelierdjames.nillafood
 
 data class InsulinInjection(
+    val id: String,
     val time: String,
     val insulin: String,
     val units: Float

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionEntity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionEntity.kt
@@ -1,17 +1,19 @@
 package com.atelierdjames.nillafood
 
 import androidx.room.Entity
+import androidx.room.PrimaryKey
 
-@Entity(tableName = "insulin_injections", primaryKeys = ["time", "insulin"])
+@Entity(tableName = "insulin_injections")
 data class InsulinInjectionEntity(
+    @PrimaryKey val id: String,
     val time: String,
     val insulin: String,
     val units: Float
 ) {
-    fun toInjection(): InsulinInjection = InsulinInjection(time, insulin, units)
+    fun toInjection(): InsulinInjection = InsulinInjection(id, time, insulin, units)
 
     companion object {
         fun from(injection: InsulinInjection): InsulinInjectionEntity =
-            InsulinInjectionEntity(injection.time, injection.insulin, injection.units)
+            InsulinInjectionEntity(injection.id, injection.time, injection.insulin, injection.units)
     }
 }


### PR DESCRIPTION
## Summary
- include an `id` field on `InsulinInjection`
- store `_id` from API as the primary key of `insulin_injections`
- bump database schema version

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754f13edf8832991ec6cf55f6c7f7d