### PR TITLE
Switch timestamp storage to Long

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -78,7 +78,7 @@ object ApiClient {
                     .appendQueryParameter("find[eventType]", "Meal Entry")
                     .appendQueryParameter("count", "100")
                     .appendQueryParameter("token", TOKEN)
-                    .apply { lastLocal?.let { appendQueryParameter("find[created_at][\$gt]", it) } }
+                    .apply { lastLocal?.let { appendQueryParameter("find[created_at][\$gt]", java.time.Instant.ofEpochMilli(it).toString()) } }
                     .build()
                 val url = URL(uri.toString())
                 val conn = url.openConnection() as HttpURLConnection
@@ -115,7 +115,7 @@ object ApiClient {
                     .appendQueryParameter("find[insulin][\$gt]", "0")
                     .appendQueryParameter("count", "100")
                     .appendQueryParameter("token", TOKEN)
-                    .apply { lastLocal?.let { appendQueryParameter("find[created_at][\$gt]", it) } }
+                    .apply { lastLocal?.let { appendQueryParameter("find[created_at][\$gt]", java.time.Instant.ofEpochMilli(it).toString()) } }
                     .build()
                 val url = URL(uri.toString())
 
@@ -128,7 +128,7 @@ object ApiClient {
                 val newInjections = mutableListOf<InsulinInjection>()
                 for (i in 0 until jsonArray.length()) {
                     val obj = jsonArray.getJSONObject(i)
-                    val time = obj.optString("created_at")
+                    val time = runCatching { java.time.Instant.parse(obj.optString("created_at")).toEpochMilli() }.getOrDefault(0L)
                     val id = obj.optString("_id")
                     val injField = obj.opt("insulinInjections")
                     val injArray = when (injField) {

--- a/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 
 @Database(
     entities = [GlucoseEntry::class, TreatmentEntity::class, InsulinInjectionEntity::class],
-    version = 5
+    version = 6
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun glucoseDao(): GlucoseDao

--- a/app/src/main/java/com/atelierdjames/nillafood/DatabaseProvider.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/DatabaseProvider.kt
@@ -2,6 +2,8 @@ package com.atelierdjames.nillafood
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 object DatabaseProvider {
     private const val DB_NAME = "app-db"
@@ -15,7 +17,23 @@ object DatabaseProvider {
                 context.applicationContext,
                 AppDatabase::class.java,
                 DB_NAME
-            ).fallbackToDestructiveMigration().build().also { INSTANCE = it }
+            ).addMigrations(MIGRATION_5_6)
+                .fallbackToDestructiveMigration()
+                .build().also { INSTANCE = it }
+        }
+    }
+
+    private val MIGRATION_5_6 = object : Migration(5, 6) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE insulin_injections RENAME TO temp_insulin")
+            db.execSQL("CREATE TABLE insulin_injections (id TEXT NOT NULL, time INTEGER NOT NULL, insulin TEXT NOT NULL, units REAL NOT NULL, PRIMARY KEY(id))")
+            db.execSQL("INSERT INTO insulin_injections (id, time, insulin, units) SELECT id, CAST(strftime('%s', time) * 1000 AS INTEGER), insulin, units FROM temp_insulin")
+            db.execSQL("DROP TABLE temp_insulin")
+
+            db.execSQL("ALTER TABLE treatments RENAME TO temp_treatments")
+            db.execSQL("CREATE TABLE treatments (id TEXT NOT NULL, carbs REAL NOT NULL, protein REAL NOT NULL, fat REAL NOT NULL, note TEXT NOT NULL, timestamp INTEGER NOT NULL, PRIMARY KEY(id))")
+            db.execSQL("INSERT INTO treatments (id, carbs, protein, fat, note, timestamp) SELECT id, carbs, protein, fat, note, CAST(strftime('%s', timestamp) * 1000 AS INTEGER) FROM temp_treatments")
+            db.execSQL("DROP TABLE temp_treatments")
         }
     }
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinAdapter.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinAdapter.kt
@@ -29,14 +29,14 @@ class InsulinAdapter : RecyclerView.Adapter<InsulinAdapter.ViewHolder>() {
             unitsText.text = item.units.toString()
         }
 
-        private fun formatDate(isoDate: String): String {
+        private fun formatDate(epoch: Long): String {
             return try {
-                val instant = Instant.parse(isoDate)
+                val instant = Instant.ofEpochMilli(epoch)
                 DateTimeFormatter.ofPattern("MMM dd, hh:mm a")
                     .withZone(ZoneId.systemDefault())
                     .format(instant)
             } catch (e: Exception) {
-                isoDate
+                epoch.toString()
             }
         }
     }

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjection.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjection.kt
@@ -2,7 +2,7 @@ package com.atelierdjames.nillafood
 
 data class InsulinInjection(
     val id: String,
-    val time: String,
+    val time: Long,
     val insulin: String,
     val units: Float
 )

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionDao.kt
@@ -14,5 +14,5 @@ interface InsulinInjectionDao {
     suspend fun insertAll(entries: List<InsulinInjectionEntity>)
 
     @Query("SELECT time FROM insulin_injections ORDER BY time DESC LIMIT 1")
-    suspend fun getLatestTimestamp(): String?
+    suspend fun getLatestTimestamp(): Long?
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionEntity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionEntity.kt
@@ -6,7 +6,7 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "insulin_injections")
 data class InsulinInjectionEntity(
     @PrimaryKey val id: String,
-    val time: String,
+    val time: Long,
     val insulin: String,
     val units: Float
 ) {

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionStorage.kt
@@ -16,7 +16,7 @@ object InsulinInjectionStorage {
         }
     }
 
-    suspend fun getLatestTimestamp(context: Context): String? {
+    suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).insulinDao().getLatestTimestamp()
     }
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -99,7 +99,8 @@ class MainActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
-            val timestamp = binding.timestampInput.text.toString()
+            val timestampText = binding.timestampInput.text.toString()
+            val timestamp = runCatching { sdf.parse(timestampText)?.time }.getOrNull() ?: System.currentTimeMillis()
             val treatment = Treatment(carbs, protein, fat, note, timestamp)
             ApiClient.sendTreatment(this, treatment) { success ->
                 runOnUiThread {
@@ -224,9 +225,9 @@ class MainActivity : AppCompatActivity() {
 
         fun hoursSince(type: String): Long? {
             val latest = list.filter { it.insulin.equals(type, ignoreCase = true) }
-                .maxByOrNull { runCatching { java.time.Instant.parse(it.time) }.getOrNull() ?: java.time.Instant.EPOCH }
+                .maxByOrNull { it.time }
             return latest?.let { inj ->
-                runCatching { java.time.Duration.between(java.time.Instant.parse(inj.time), now).toHours() }.getOrNull()
+                runCatching { java.time.Duration.between(java.time.Instant.ofEpochMilli(inj.time), now).toHours() }.getOrNull()
             }
         }
 

--- a/app/src/main/java/com/atelierdjames/nillafood/OfflineStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/OfflineStorage.kt
@@ -26,7 +26,7 @@ object OfflineStorage {
                 protein = json.getDouble("protein").toFloat(),
                 fat = json.getDouble("fat").toFloat(),
                 note = json.getString("notes"),
-                timestamp = json.getString("created_at")
+                timestamp = runCatching { java.time.Instant.parse(json.getString("created_at")).toEpochMilli() }.getOrDefault(0L)
             )
             ApiClient.sendTreatment(context, t) { success ->
                 if (!success) remaining.add(entry)

--- a/app/src/main/java/com/atelierdjames/nillafood/Treatment.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/Treatment.kt
@@ -1,7 +1,8 @@
 package com.atelierdjames.nillafood
 
 import org.json.JSONObject
-import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 import java.util.*
 
 data class Treatment(
@@ -9,7 +10,7 @@ data class Treatment(
     val protein: Float,
     val fat: Float,
     val note: String,
-    val timestamp: String = getUtcTimestamp(),
+    val timestamp: Long = getUtcTimestamp(),
     val id: String? = null
 ) {
     fun toJson(): JSONObject {
@@ -19,16 +20,18 @@ data class Treatment(
             put("protein", protein)
             put("fat", fat)
             put("notes", note)
-            put("created_at", timestamp)
+            put("created_at", DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(timestamp)))
             put("enteredBy", "Nilla")
         }
     }
 
     companion object {
-        fun getUtcTimestamp(): String {
-            val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
-            sdf.timeZone = TimeZone.getTimeZone("UTC")
-            return sdf.format(Date())
+        fun getUtcTimestamp(): Long {
+            return System.currentTimeMillis()
+        }
+
+        private fun parseTimestamp(ts: String): Long {
+            return runCatching { Instant.parse(ts).toEpochMilli() }.getOrDefault(0L)
         }
 
         fun fromJson(json: JSONObject): Treatment {
@@ -37,7 +40,7 @@ data class Treatment(
                 protein = json.optDouble("protein", 0.0).toFloat(),
                 fat = json.optDouble("fat", 0.0).toFloat(),
                 note = json.optString("notes", ""),
-                timestamp = json.optString("created_at", ""),
+                timestamp = parseTimestamp(json.optString("created_at", "")),
                 id = json.optString("_id", null)
             )
         }

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentAdapter.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentAdapter.kt
@@ -57,14 +57,14 @@ class TreatmentAdapter(
             deleteButton.setOnClickListener { onDelete(treatment) }
         }
 
-        private fun formatDate(isoDate: String): String {
+        private fun formatDate(epoch: Long): String {
             return try {
-                val instant = Instant.parse(isoDate)
+                val instant = Instant.ofEpochMilli(epoch)
                 DateTimeFormatter.ofPattern("MMM dd, hh:mm a")
                     .withZone(ZoneId.systemDefault())
                     .format(instant)
             } catch (e: Exception) {
-                isoDate
+                epoch.toString()
             }
         }
     }

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentDao.kt
@@ -14,5 +14,5 @@ interface TreatmentDao {
     suspend fun insertAll(entries: List<TreatmentEntity>)
 
     @Query("SELECT timestamp FROM treatments ORDER BY timestamp DESC LIMIT 1")
-    suspend fun getLatestTimestamp(): String?
+    suspend fun getLatestTimestamp(): Long?
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentEntity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentEntity.kt
@@ -10,7 +10,7 @@ data class TreatmentEntity(
     val protein: Float,
     val fat: Float,
     val note: String,
-    val timestamp: String
+    val timestamp: Long
 ) {
     fun toTreatment(): Treatment = Treatment(carbs, protein, fat, note, timestamp, id)
 

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentStorage.kt
@@ -16,7 +16,7 @@ object TreatmentStorage {
         }
     }
 
-    suspend fun getLatestTimestamp(context: Context): String? {
+    suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).treatmentDao().getLatestTimestamp()
     }
 }


### PR DESCRIPTION
## Summary
- store timestamps as epoch milliseconds in TreatmentEntity and InsulinInjectionEntity
- update domain models and adapters to work with longs
- serialize/deserialize timestamps as ISO strings in ApiClient
- migrate existing DB data from version 5 to version 6

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687564562cf08329ac2121d7aff588a9