### PR TITLE
Add MealImpact DAO and tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     testImplementation(libs.junit)
+    testImplementation("androidx.room:room-testing:2.6.1")
+    testImplementation("androidx.test:core:1.5.0")
 
     // Iconics core + views (keep versions in sync)
     // core + views modules for Iconics

--- a/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/AppDatabase.kt
@@ -12,4 +12,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun treatmentDao(): TreatmentDao
     abstract fun insulinDao(): InsulinInjectionDao
     abstract fun analyticsDao(): AnalyticsDao
+    abstract fun mealDao(): MealDao
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/MealDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MealDao.kt
@@ -1,0 +1,21 @@
+package com.atelierdjames.nillafood
+
+import androidx.room.Dao
+import androidx.room.Query
+
+@Dao
+interface MealDao {
+    @Query(
+        """
+        SELECT carbs, peak, peak - baseline AS delta FROM (
+            SELECT
+                tr.carbs AS carbs,
+                (SELECT sgv FROM glucose_entries ge WHERE ge.date <= tr.timestamp ORDER BY ge.date DESC LIMIT 1) AS baseline,
+                (SELECT MAX(ge2.sgv) FROM glucose_entries ge2 WHERE ge2.date > tr.timestamp AND ge2.date <= tr.timestamp + 7200000) AS peak
+            FROM treatments tr
+            ORDER BY tr.timestamp DESC
+        )
+        """
+    )
+    suspend fun getRecentMealImpacts(): List<MealImpact>
+}

--- a/app/src/main/java/com/atelierdjames/nillafood/MealImpact.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MealImpact.kt
@@ -1,0 +1,14 @@
+package com.atelierdjames.nillafood
+
+/**
+ * Summary of a meal's effect on glucose levels.
+ *
+ * @property carbs carbohydrate grams of the meal
+ * @property peak maximum glucose value within two hours after the meal
+ * @property delta difference between the peak and glucose immediately before the meal
+ */
+data class MealImpact(
+    val carbs: Float,
+    val peak: Float?,
+    val delta: Float?
+)

--- a/app/src/test/java/com/atelierdjames/nillafood/MealDaoTest.kt
+++ b/app/src/test/java/com/atelierdjames/nillafood/MealDaoTest.kt
@@ -1,0 +1,65 @@
+package com.atelierdjames.nillafood
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class MealDaoTest {
+    private lateinit var db: AppDatabase
+    private lateinit var mealDao: MealDao
+    private lateinit var treatmentDao: TreatmentDao
+    private lateinit var glucoseDao: GlucoseDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        mealDao = db.mealDao()
+        treatmentDao = db.treatmentDao()
+        glucoseDao = db.glucoseDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun simpleMealImpact() = runBlocking {
+        val meal = TreatmentEntity("m1", 20f, 0f, 0f, "", 1000L)
+        treatmentDao.insertAll(listOf(meal))
+        val baseline = GlucoseEntry("g1", 100f, null, null, 900L, null)
+        val peak = GlucoseEntry("g2", 150f, null, null, 5400L, null)
+        glucoseDao.insertAll(listOf(baseline, peak))
+
+        val impacts = mealDao.getRecentMealImpacts()
+        assertEquals(1, impacts.size)
+        val impact = impacts[0]
+        assertEquals(20f, impact.carbs, 0.001f)
+        assertEquals(150f, impact.peak!!, 0.001f)
+        assertEquals(50f, impact.delta!!, 0.001f)
+    }
+
+    @Test
+    fun noDataAfterMeal() = runBlocking {
+        val meal = TreatmentEntity("m2", 30f, 0f, 0f, "", 10000L)
+        treatmentDao.insertAll(listOf(meal))
+        val baseline = GlucoseEntry("g3", 110f, null, null, 9900L, null)
+        glucoseDao.insertAll(listOf(baseline))
+
+        val impacts = mealDao.getRecentMealImpacts()
+        assertEquals(1, impacts.size)
+        val impact = impacts[0]
+        assertNull(impact.peak)
+        assertNull(impact.delta)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `MealImpact` data class
- implement `MealDao.getRecentMealImpacts()` query
- expose new DAO from `AppDatabase`
- add Room testing libraries
- add unit tests for `MealDao`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875690d73588329943c6dacb1eaf206