### PR TITLE
Add analytics flows and charts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation("com.google.android.material:material:1.12.0")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1")
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/java/com/atelierdjames/nillafood/AnalyticsRepository.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/AnalyticsRepository.kt
@@ -9,4 +9,13 @@ object AnalyticsRepository {
     fun streamFeatures(context: Context, start: Long): Flow<List<TimepointFeatures>> {
         return db(context).analyticsDao().streamFeatures(start)
     }
+
+    fun streamIOB(context: Context, activityWindowMs: Long): Flow<List<IOBPoint>> {
+        return db(context).insulinDao().streamIOB(activityWindowMs)
+    }
+
+    fun streamMealImpacts(context: Context): Flow<List<MealImpact>> =
+        kotlinx.coroutines.flow.flow {
+            emit(db(context).mealDao().getRecentMealImpacts())
+        }
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/AnalyticsViewModel.kt
@@ -1,0 +1,34 @@
+package com.atelierdjames.nillafood
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+class AnalyticsViewModel(application: Application) : AndroidViewModel(application) {
+    private val repo = AnalyticsRepository
+    private val ctx = getApplication<Application>()
+
+    val featureFlow: StateFlow<List<TimepointFeatures>> =
+        repo.streamFeatures(ctx, 0L).stateIn(
+            viewModelScope,
+            SharingStarted.Lazily,
+            emptyList()
+        )
+
+    val iobFlow: StateFlow<List<IOBPoint>> =
+        repo.streamIOB(ctx, 4 * 60 * 60 * 1000L).stateIn(
+            viewModelScope,
+            SharingStarted.Lazily,
+            emptyList()
+        )
+
+    val mealImpacts: StateFlow<List<MealImpact>> =
+        repo.streamMealImpacts(ctx).stateIn(
+            viewModelScope,
+            SharingStarted.Lazily,
+            emptyList()
+        )
+}

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -9,8 +9,13 @@ import android.view.View
 import java.text.SimpleDateFormat
 import java.util.*
 import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.Lifecycle
+import kotlinx.coroutines.launch
 import com.google.android.material.tabs.TabLayout
 import com.atelierdjames.nillafood.databinding.ActivityMainBinding
 import com.atelierdjames.nillafood.InsulinAdapter
@@ -20,6 +25,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private lateinit var adapter: TreatmentAdapter
     private lateinit var insulinAdapter: InsulinAdapter
+    private val analyticsViewModel: AnalyticsViewModel by viewModels()
     private val TAG = "MainActivity"
     private val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     private val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
@@ -117,6 +123,8 @@ class MainActivity : AppCompatActivity() {
         binding.refreshMealsButton.setOnClickListener { loadTreatments() }
         binding.refreshInsulinButton.setOnClickListener { loadInsulinTreatments() }
         binding.refreshStatsButton.setOnClickListener { loadStats() }
+
+        observeAnalytics()
     }
 
     private fun setupMealRecyclerView() {
@@ -239,6 +247,44 @@ class MainActivity : AppCompatActivity() {
         tres?.let { parts.add(getString(R.string.last_scan_format, "Tresiba", it)) }
 
         binding.lastScanText.text = parts.joinToString("\n")
+    }
+
+    private fun observeAnalytics() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(androidx.lifecycle.Lifecycle.State.STARTED) {
+                launch {
+                    analyticsViewModel.iobFlow.collect { points ->
+                        val current = points.lastOrNull()?.iob ?: 0f
+                        binding.currentIobText.text = getString(R.string.current_iob_format, current)
+                    }
+                }
+                launch {
+                    analyticsViewModel.mealImpacts.collect { impacts ->
+                        val avg = impacts.mapNotNull { it.delta }.average().toFloatOrNull() ?: Float.NaN
+                        if (!avg.isNaN()) {
+                            binding.avgSpikeText.text = getString(R.string.average_spike_format, avg)
+                        }
+                        val summaries = impacts.take(3)
+                        val cards = listOf(binding.meal1Text, binding.meal2Text, binding.meal3Text)
+                        for (i in cards.indices) {
+                            val imp = summaries.getOrNull(i)
+                            cards[i].text = imp?.let { getString(R.string.meal_summary_format, it.carbs, it.delta ?: Float.NaN) } ?: ""
+                        }
+                    }
+                }
+                launch {
+                    analyticsViewModel.featureFlow.collect { features ->
+                        val entries = features.mapNotNull { it.glucose?.let { g -> com.github.mikephil.charting.data.Entry(it.ts.toFloat(), g) } }
+                        val lineSet = com.github.mikephil.charting.data.LineDataSet(entries, "Glucose")
+                        val iobEntries = analyticsViewModel.iobFlow.value.map { com.github.mikephil.charting.data.Entry(it.ts.toFloat(), it.iob * 20f) }
+                        val iobSet = com.github.mikephil.charting.data.LineDataSet(iobEntries, "IOB")
+                        val data = com.github.mikephil.charting.data.LineData(lineSet, iobSet)
+                        binding.analyticsChart.data = data
+                        binding.analyticsChart.invalidate()
+                    }
+                }
+            }
+        }
     }
     private fun resetForm() {
         binding.carbsInput.text?.clear()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -326,6 +326,84 @@
             android:layout_width="match_parent"
             android:layout_height="150dp" />
 
+        <com.github.mikephil.charting.charts.LineChart
+            android:id="@+id/analyticsChart"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="16dp" />
+
+        <LinearLayout
+            android:id="@+id/summaryContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginTop="16dp">
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/currentIobCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp">
+
+                <TextView
+                    android:id="@+id/currentIobText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/avgSpikeCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp">
+
+                <TextView
+                    android:id="@+id/avgSpikeText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/meal1Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp">
+
+                <TextView
+                    android:id="@+id/meal1Text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/meal2Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp">
+
+                <TextView
+                    android:id="@+id/meal2Text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/meal3Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/meal3Text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp" />
+            </com.google.android.material.card.MaterialCardView>
+        </LinearLayout>
+
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="hba1c_format">Est. HbA1c: %.1f mmol/mol</string>
     <string name="sd_format">SD: %.1f mmol/L</string>
     <string name="refresh">Refresh</string>
+    <string name="current_iob_format">Current IOB: %.1fU</string>
+    <string name="average_spike_format">Average Spike: %.1f</string>
+    <string name="meal_summary_format">Meal %1$.0fg Δ%2$.1f</string>
 </resources>


### PR DESCRIPTION
## Summary
- expose IOB and meal impact flows via `AnalyticsRepository`
- provide `AnalyticsViewModel` exposing flows as `StateFlow`
- show combined glucose and IOB line chart with meal summaries
- add summary cards for IOB and meal impacts
- lifecycle-aware collection of flows

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757e57a3a08329b7d2569e2fdc8f68