### PR TITLE
Add treatment delete syncing

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -72,13 +72,11 @@ object ApiClient {
 
     fun getRecentTreatments(context: Context, callback: (List<Treatment>?) -> Unit) {
         CoroutineScope(Dispatchers.IO).launch {
-            val lastLocal = TreatmentStorage.getLatestTimestamp(context)
             try {
                 val uri = NIGHTSCOUT_URL.toUri().buildUpon()
                     .appendQueryParameter("find[eventType]", "Meal Entry")
                     .appendQueryParameter("count", "100")
                     .appendQueryParameter("token", TOKEN)
-                    .apply { lastLocal?.let { appendQueryParameter("find[created_at][\$gt]", java.time.Instant.ofEpochMilli(it).toString()) } }
                     .build()
                 val url = URL(uri.toString())
                 val conn = url.openConnection() as HttpURLConnection
@@ -95,7 +93,7 @@ object ApiClient {
                         newTreatments.add(Treatment.fromJson(jsonObject))
                     }
                 }
-                TreatmentStorage.addOrUpdate(context, newTreatments)
+                TreatmentStorage.replaceAll(context, newTreatments)
             } catch (e: Exception) {
                 e.printStackTrace()
             }

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -15,6 +15,9 @@ import com.google.android.material.tabs.TabLayout
 import com.atelierdjames.nillafood.databinding.ActivityMainBinding
 import com.atelierdjames.nillafood.InsulinAdapter
 import com.atelierdjames.nillafood.InsulinInjection
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
@@ -257,6 +260,9 @@ class MainActivity : AppCompatActivity() {
         ApiClient.deleteTreatment(id) { success ->
             runOnUiThread {
                 if (success) {
+                    CoroutineScope(Dispatchers.IO).launch {
+                        TreatmentStorage.delete(this@MainActivity, id)
+                    }
                     Toast.makeText(this, "Deleted", Toast.LENGTH_SHORT).show()
                     loadTreatments()
                 } else {

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentDao.kt
@@ -13,6 +13,12 @@ interface TreatmentDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(entries: List<TreatmentEntity>)
 
+    @Query("DELETE FROM treatments WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM treatments")
+    suspend fun deleteAll()
+
     @Query("SELECT timestamp FROM treatments ORDER BY timestamp DESC LIMIT 1")
     suspend fun getLatestTimestamp(): Long?
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentStorage.kt
@@ -16,6 +16,19 @@ object TreatmentStorage {
         }
     }
 
+    suspend fun replaceAll(context: Context, treatments: List<Treatment>) {
+        val dao = db(context).treatmentDao()
+        dao.deleteAll()
+        val entities = treatments.mapNotNull { TreatmentEntity.from(it) }
+        if (entities.isNotEmpty()) {
+            dao.insertAll(entities)
+        }
+    }
+
+    suspend fun delete(context: Context, id: String) {
+        db(context).treatmentDao().deleteById(id)
+    }
+
     suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).treatmentDao().getLatestTimestamp()
     }


### PR DESCRIPTION
## Summary
- add delete queries in `TreatmentDao`
- expose delete & replaceAll operations in `TreatmentStorage`
- refresh treatments using `replaceAll` when loading
- remove local item after successful server delete

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760385b1748329934585afefd1cbe8