### PR TITLE
Implement data refresh on start and tab changes

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -69,6 +69,7 @@ class MainActivity : AppCompatActivity() {
         setupInsulinRecyclerView()
         loadInsulinTreatments()
         loadTreatments()
+        loadStats()
         OfflineStorage.retryUnsyncedData(this)
 
         binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
@@ -78,11 +79,13 @@ class MainActivity : AppCompatActivity() {
                         binding.mealsLayout.visibility = View.VISIBLE
                         binding.insulinLayout.visibility = View.GONE
                         binding.nightscoutLayout.visibility = View.GONE
+                        loadTreatments()
                     }
                     1 -> {
                         binding.mealsLayout.visibility = View.GONE
                         binding.insulinLayout.visibility = View.VISIBLE
                         binding.nightscoutLayout.visibility = View.GONE
+                        loadInsulinTreatments()
                     }
                     else -> {
                         binding.mealsLayout.visibility = View.GONE


### PR DESCRIPTION
## Summary
- trigger stats calculation when app starts
- refresh meals and insulin data whenever their tab is selected

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687625a48c288329ae6b356b003a8b79