### PR TITLE
Show HbA1c data range

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -328,6 +328,15 @@ object ApiClient {
             val hba1cPercent = if (!overallAvgMgdl.isNaN()) (overallAvgMgdl + 46.7f) / 28.7f else Float.NaN
             val hba1cMmolMol = if (!hba1cPercent.isNaN()) hba1cPercent * 10.93f else Float.NaN
 
+            val earliestTs = GlucoseStorage.getEarliestTimestamp(context)
+            val latestTs = GlucoseStorage.getLatestTimestamp(context)
+            val daysUsed = if (earliestTs != null && latestTs != null) {
+                java.time.temporal.ChronoUnit.DAYS.between(
+                    java.time.Instant.ofEpochMilli(earliestTs),
+                    java.time.Instant.ofEpochMilli(latestTs)
+                ).toInt() + 1
+            } else 0
+
             val stats = GlucoseStats(
                 avg24h = avgFor(1),
                 avg7d = avgFor(7),
@@ -336,7 +345,8 @@ object ApiClient {
                 tir7d = tirFor(7),
                 tir14d = tirFor(14),
                 hba1c = hba1cMmolMol,
-                sd = sd
+                sd = sd,
+                daysUsed = daysUsed
             )
 
             withContext(Dispatchers.Main) { callback(stats) }

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseDao.kt
@@ -15,4 +15,7 @@ interface GlucoseDao {
 
     @Query("SELECT date FROM glucose_entries ORDER BY date DESC LIMIT 1")
     suspend fun getLatestTimestamp(): Long?
+
+    @Query("SELECT date FROM glucose_entries ORDER BY date ASC LIMIT 1")
+    suspend fun getEarliestTimestamp(): Long?
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseStats.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseStats.kt
@@ -14,5 +14,6 @@ data class GlucoseStats(
     val tir7d: TimeInRange,
     val tir14d: TimeInRange,
     val hba1c: Float,
-    val sd: Float
+    val sd: Float,
+    val daysUsed: Int
 )

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
@@ -19,4 +19,8 @@ object GlucoseStorage {
     suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).glucoseDao().getLatestTimestamp()
     }
+
+    suspend fun getEarliestTimestamp(context: Context): Long? {
+        return db(context).glucoseDao().getEarliestTimestamp()
+    }
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -195,6 +195,7 @@ class MainActivity : AppCompatActivity() {
         binding.averageGlucose7.text = getString(R.string.average_glucose_placeholder)
         binding.averageGlucose14.text = getString(R.string.average_glucose_placeholder)
         binding.hba1cText.text = getString(R.string.hba1c_placeholder)
+        binding.hba1cDaysText.text = ""
         binding.sdText.text = getString(R.string.sd_placeholder)
 
         ApiClient.getGlucoseStats(this) { result ->
@@ -205,6 +206,11 @@ class MainActivity : AppCompatActivity() {
                     binding.averageGlucose7.text = if (!stats.avg7d.isNaN()) getString(R.string.average_glucose_7d_format, stats.avg7d) else placeholder
                     binding.averageGlucose14.text = if (!stats.avg14d.isNaN()) getString(R.string.average_glucose_14d_format, stats.avg14d) else placeholder
                     binding.hba1cText.text = if (!stats.hba1c.isNaN()) getString(R.string.hba1c_format, stats.hba1c) else getString(R.string.hba1c_placeholder)
+                    if (stats.daysUsed > 0) {
+                        binding.hba1cDaysText.text = getString(R.string.hba1c_days_format, stats.daysUsed)
+                    } else {
+                        binding.hba1cDaysText.text = ""
+                    }
                     binding.sdText.text = if (!stats.sd.isNaN()) getString(R.string.sd_format, stats.sd) else getString(R.string.sd_placeholder)
                     setupPieChart(binding.pie24h, stats.tir24h)
                     setupPieChart(binding.pie7d, stats.tir7d)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -276,6 +276,15 @@
             android:padding="8dp" />
 
         <TextView
+            android:id="@+id/hba1cDaysText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textAlignment="center"
+            android:textSize="14sp"
+            android:padding="4dp" />
+
+        <TextView
             android:id="@+id/sdText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="hba1c_placeholder">HbA1c loading...</string>
     <string name="sd_placeholder">SD loading...</string>
     <string name="hba1c_format">Est. HbA1c: %.1f mmol/mol</string>
+    <string name="hba1c_days_format">Using last %1$d days of data</string>
     <string name="sd_format">SD: %.1f mmol/L</string>
     <string name="refresh">Refresh</string>
 </resources>


### PR DESCRIPTION
## Summary
- expose earliest glucose timestamp from DB
- compute range of days used for HbA1c
- display HbA1c range on stats tab

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763879e0b08329893df20aff508444