### PR TITLE
Extend insulin usage summary with macros

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionStorage.kt
@@ -27,28 +27,41 @@ object InsulinInjectionStorage {
         val startMillis = startDate.atStartOfDay(zone).toInstant().toEpochMilli()
 
         val injections = db(context).insulinDao().getSince(startMillis).map { it.toInjection() }
+        val treatments = db(context).treatmentDao().getSince(startMillis).map { it.toTreatment() }
 
         val map = mutableMapOf<java.time.LocalDate, FloatArray>()
         for (inj in injections) {
             val date = java.time.Instant.ofEpochMilli(inj.time).atZone(zone).toLocalDate()
             if (date.isBefore(startDate) || date.isAfter(today)) continue
-            val totals = map.getOrPut(date) { floatArrayOf(0f, 0f) }
+            val totals = map.getOrPut(date) { floatArrayOf(0f, 0f, 0f, 0f, 0f) }
             when {
                 inj.insulin.equals("Novorapid", ignoreCase = true) -> totals[0] += inj.units
                 inj.insulin.equals("Tresiba", ignoreCase = true) -> totals[1] += inj.units
             }
         }
 
+        for (t in treatments) {
+            val date = java.time.Instant.ofEpochMilli(t.timestamp).atZone(zone).toLocalDate()
+            if (date.isBefore(startDate) || date.isAfter(today)) continue
+            val totals = map.getOrPut(date) { floatArrayOf(0f, 0f, 0f, 0f, 0f) }
+            totals[2] += t.carbs
+            totals[3] += t.protein
+            totals[4] += t.fat
+        }
+
         val formatter = java.time.format.DateTimeFormatter.ofPattern("MMM dd")
         val result = mutableListOf<InsulinUsageSummary>()
         for (i in 0..6) {
             val date = startDate.plusDays(i.toLong())
-            val totals = map[date] ?: floatArrayOf(0f, 0f)
+            val totals = map[date] ?: floatArrayOf(0f, 0f, 0f, 0f, 0f)
             result.add(
                 InsulinUsageSummary(
                     day = date.format(formatter),
                     novorapid = totals[0],
-                    tresiba = totals[1]
+                    tresiba = totals[1],
+                    carbs = totals[2],
+                    protein = totals[3],
+                    fat = totals[4]
                 )
             )
         }

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinUsageAdapter.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinUsageAdapter.kt
@@ -19,11 +19,17 @@ class InsulinUsageAdapter : RecyclerView.Adapter<InsulinUsageAdapter.ViewHolder>
         private val dateText: TextView = itemView.findViewById(R.id.insulinUsageDate)
         private val novaText: TextView = itemView.findViewById(R.id.insulinUsageNovorapid)
         private val tresText: TextView = itemView.findViewById(R.id.insulinUsageTresiba)
+        private val carbText: TextView = itemView.findViewById(R.id.insulinUsageCarbs)
+        private val proteinText: TextView = itemView.findViewById(R.id.insulinUsageProtein)
+        private val fatText: TextView = itemView.findViewById(R.id.insulinUsageFat)
 
         fun bind(item: InsulinUsageSummary) {
             dateText.text = item.day
             novaText.text = item.novorapid.toString()
             tresText.text = item.tresiba.toString()
+            carbText.text = item.carbs.toString()
+            proteinText.text = item.protein.toString()
+            fatText.text = item.fat.toString()
         }
     }
 

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinUsageSummary.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinUsageSummary.kt
@@ -3,5 +3,8 @@ package com.atelierdjames.nillafood
 data class InsulinUsageSummary(
     val day: String,
     val novorapid: Float,
-    val tresiba: Float
+    val tresiba: Float,
+    val carbs: Float,
+    val protein: Float,
+    val fat: Float
 )

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentDao.kt
@@ -21,4 +21,7 @@ interface TreatmentDao {
 
     @Query("SELECT timestamp FROM treatments ORDER BY timestamp DESC LIMIT 1")
     suspend fun getLatestTimestamp(): Long?
+
+    @Query("SELECT * FROM treatments WHERE timestamp >= :start")
+    suspend fun getSince(start: Long): List<TreatmentEntity>
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/TreatmentStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/TreatmentStorage.kt
@@ -32,4 +32,8 @@ object TreatmentStorage {
     suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).treatmentDao().getLatestTimestamp()
     }
+
+    suspend fun getSince(context: Context, start: Long): List<Treatment> {
+        return db(context).treatmentDao().getSince(start).map { it.toTreatment() }
+    }
 }

--- a/app/src/main/res/layout/insulin_usage_item.xml
+++ b/app/src/main/res/layout/insulin_usage_item.xml
@@ -24,4 +24,25 @@
         android:layout_weight="1"
         android:gravity="center_horizontal" />
 
+    <TextView
+        android:id="@+id/insulinUsageCarbs"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center_horizontal" />
+
+    <TextView
+        android:id="@+id/insulinUsageProtein"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center_horizontal" />
+
+    <TextView
+        android:id="@+id/insulinUsageFat"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center_horizontal" />
+
 </LinearLayout>


### PR DESCRIPTION
## Summary
- show daily carbs, protein, and fat totals in the insulin usage list
- compute these macros using Room queries

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876484bb0948329a05d513f74b52df4