### PR TITLE
Add master refresh button and sync function

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -11,6 +11,7 @@ import com.atelierdjames.nillafood.GlucoseStats
 import com.atelierdjames.nillafood.GlucoseStorage
 import com.atelierdjames.nillafood.GlucoseEntry
 import com.atelierdjames.nillafood.TreatmentStorage
+import com.atelierdjames.nillafood.InsulinInjectionStorage
 import org.json.JSONObject
 import androidx.core.net.toUri
 import com.atelierdjames.nillafood.TimeInRange
@@ -371,5 +372,139 @@ object ApiClient {
                 }
             }
         }
+    }
+
+    fun masterRefresh(context: Context, callback: () -> Unit) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val now = java.time.Instant.now()
+            val start = now.minus(60, java.time.temporal.ChronoUnit.DAYS)
+
+            val treatments = fetchAllTreatments(start)
+            val injections = fetchAllInjections(start)
+            val glucose = fetchAllGlucose(start, now)
+
+            TreatmentStorage.replaceAll(context, treatments)
+            InsulinInjectionStorage.replaceAll(context, injections)
+            GlucoseStorage.replaceAll(context, glucose)
+
+            withContext(Dispatchers.Main) { callback() }
+        }
+    }
+
+    private suspend fun fetchAllTreatments(start: java.time.Instant): List<Treatment> {
+        val result = mutableListOf<Treatment>()
+        var skip = 0
+        val count = 1000
+        while (true) {
+            val uri = NIGHTSCOUT_URL.toUri().buildUpon()
+                .appendQueryParameter("find[eventType]", "Meal Entry")
+                .appendQueryParameter("count", count.toString())
+                .appendQueryParameter("skip", skip.toString())
+                .appendQueryParameter("token", TOKEN)
+                .build()
+            val url = URL(uri.toString())
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "GET"
+            val text = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+            val arr = JSONArray(text)
+            var added = 0
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                val ts = runCatching { java.time.Instant.parse(obj.optString("created_at")) }.getOrNull()
+                if (ts != null && ts.isBefore(start)) return result
+                if (obj.optString("eventType") == "Meal Entry") {
+                    result.add(Treatment.fromJson(obj))
+                    added++
+                }
+            }
+            if (added < count) break
+            skip += count
+        }
+        return result
+    }
+
+    private suspend fun fetchAllInjections(start: java.time.Instant): List<InsulinInjection> {
+        val result = mutableListOf<InsulinInjection>()
+        var skip = 0
+        val count = 1000
+        while (true) {
+            val uri = NIGHTSCOUT_URL.toUri().buildUpon()
+                .appendQueryParameter("find[insulin][\$gt]", "0")
+                .appendQueryParameter("count", count.toString())
+                .appendQueryParameter("skip", skip.toString())
+                .appendQueryParameter("token", TOKEN)
+                .build()
+            val url = URL(uri.toString())
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "GET"
+            val text = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+            val arr = JSONArray(text)
+            if (arr.length() == 0) break
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                val time = runCatching { java.time.Instant.parse(obj.optString("created_at")) }.getOrNull()
+                if (time != null && time.isBefore(start)) return result
+                val id = obj.optString("_id")
+                val injField = obj.opt("insulinInjections")
+                val injArray = when (injField) {
+                    is JSONArray -> injField
+                    is String -> try { JSONArray(injField) } catch (_: Exception) { JSONArray() }
+                    else -> JSONArray()
+                }
+                if (injArray.length() == 0 && obj.has("insulin")) {
+                    val units = obj.optDouble("insulin", 0.0).toFloat()
+                    val name = obj.optString("insulinType", "")
+                    result.add(InsulinInjection(id, time?.toEpochMilli() ?: 0L, name, units))
+                }
+                for (j in 0 until injArray.length()) {
+                    val inj = injArray.getJSONObject(j)
+                    val name = inj.optString("insulin")
+                    val units = inj.optDouble("units", 0.0).toFloat()
+                    val uniqueId = "$id-$j"
+                    result.add(InsulinInjection(uniqueId, time?.toEpochMilli() ?: 0L, name, units))
+                }
+            }
+            if (arr.length() < count) break
+            skip += count
+        }
+        return result
+    }
+
+    private suspend fun fetchAllGlucose(start: java.time.Instant, end: java.time.Instant): List<GlucoseEntry> {
+        val formatter = java.time.format.DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            .withZone(java.time.ZoneOffset.UTC)
+        val result = mutableListOf<GlucoseEntry>()
+        var skip = 0
+        val count = 1000
+        while (true) {
+            val uri = ENTRIES_URL.toUri().buildUpon()
+                .appendQueryParameter("find[dateString][\$gte]", formatter.format(start))
+                .appendQueryParameter("find[dateString][\$lte]", formatter.format(end))
+                .appendQueryParameter("count", count.toString())
+                .appendQueryParameter("skip", skip.toString())
+                .build()
+            val url = URL(uri.toString())
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "GET"
+            val text = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+            val arr = JSONArray(text)
+            if (arr.length() == 0) break
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                val sgv = obj.optDouble("sgv", Double.NaN)
+                val id = obj.optString("_id")
+                val direction = obj.optString("direction", null)
+                val device = obj.optString("device", null)
+                val date = parseGlucoseTime(obj)
+                val noise = if (obj.has("noise")) obj.optInt("noise") else null
+                if (!sgv.isNaN() && id.isNotEmpty()) {
+                    result.add(GlucoseEntry(id, sgv.toFloat(), direction, device, date, noise))
+                }
+            }
+            if (arr.length() < count) break
+            skip += count
+        }
+        return result
     }
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseDao.kt
@@ -18,4 +18,7 @@ interface GlucoseDao {
 
     @Query("SELECT date FROM glucose_entries ORDER BY date ASC LIMIT 1")
     suspend fun getEarliestTimestamp(): Long?
+
+    @Query("DELETE FROM glucose_entries")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
@@ -16,6 +16,14 @@ object GlucoseStorage {
         db(context).glucoseDao().insertAll(entries)
     }
 
+    suspend fun replaceAll(context: Context, entries: List<GlucoseEntry>) {
+        val dao = db(context).glucoseDao()
+        dao.deleteAll()
+        if (entries.isNotEmpty()) {
+            dao.insertAll(entries)
+        }
+    }
+
     suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).glucoseDao().getLatestTimestamp()
     }

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionDao.kt
@@ -18,4 +18,7 @@ interface InsulinInjectionDao {
 
     @Query("SELECT time FROM insulin_injections ORDER BY time DESC LIMIT 1")
     suspend fun getLatestTimestamp(): Long?
+
+    @Query("DELETE FROM insulin_injections")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionStorage.kt
@@ -16,6 +16,15 @@ object InsulinInjectionStorage {
         }
     }
 
+    suspend fun replaceAll(context: Context, injections: List<InsulinInjection>) {
+        val dao = db(context).insulinDao()
+        dao.deleteAll()
+        val entities = injections.map { InsulinInjectionEntity.from(it) }
+        if (entities.isNotEmpty()) {
+            dao.insertAll(entities)
+        }
+    }
+
     suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).insulinDao().getLatestTimestamp()
     }

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -145,6 +145,16 @@ class MainActivity : AppCompatActivity() {
             }
         }
         binding.refreshMealsButton.setOnClickListener { loadTreatments() }
+        binding.masterRefreshButton.setOnClickListener {
+            ApiClient.masterRefresh(this) {
+                runOnUiThread {
+                    loadTreatments()
+                    loadInsulinTreatments()
+                    loadInsulinUsage()
+                    loadStats()
+                }
+            }
+        }
         binding.refreshInsulinButton.setOnClickListener { loadInsulinTreatments() }
         binding.refreshInsulinUsageButton.setOnClickListener { loadInsulinUsage() }
         binding.refreshStatsButton.setOnClickListener { loadStats() }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -198,6 +198,12 @@
             android:layout_height="wrap_content"
             android:text="@string/refresh" />
 
+        <Button
+            android:id="@+id/masterRefreshButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/master_refresh" />
+
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="hba1c_days_format">Using last %1$d days of data</string>
     <string name="sd_format">SD: %.1f mmol/L</string>
     <string name="refresh">Refresh</string>
+    <string name="master_refresh">Master Refresh</string>
 </resources>


### PR DESCRIPTION
## Summary
- add master refresh button to meals tab
- implement API-based masterRefresh to reload last 60 days of data in batches
- support replacing local data for glucose entries, insulin injections and treatments
- update Room DAOs and storage helpers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764eb33f6883298302ebfda40b1991