### PR TITLE
Improve master refresh performance

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -146,8 +146,10 @@ class MainActivity : AppCompatActivity() {
         }
         binding.refreshMealsButton.setOnClickListener { loadTreatments() }
         binding.masterRefreshButton.setOnClickListener {
+            binding.masterRefreshButton.isEnabled = false
             ApiClient.masterRefresh(this) {
                 runOnUiThread {
+                    binding.masterRefreshButton.isEnabled = true
                     loadTreatments()
                     loadInsulinTreatments()
                     loadInsulinUsage()


### PR DESCRIPTION
## Summary
- filter master refresh queries by date and sort descending
- paginate without `skip` using the last record timestamp
- disable the master refresh button during refresh to avoid duplicate clicks

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876540abb78832981b6d7a0e09281f8