### PR TITLE
Fix crash when Nightscout API returns empty body

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -409,7 +409,9 @@ object ApiClient {
             val url = URL(uri.toString())
             val conn = url.openConnection() as HttpURLConnection
             conn.requestMethod = "GET"
-            val text = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+            val stream = if (conn.responseCode in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
+            if (!text.trim().startsWith("[")) break
             val arr = JSONArray(text)
             for (i in 0 until arr.length()) {
                 val obj = arr.getJSONObject(i)
@@ -442,7 +444,9 @@ object ApiClient {
             val url = URL(uri.toString())
             val conn = url.openConnection() as HttpURLConnection
             conn.requestMethod = "GET"
-            val text = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+            val stream = if (conn.responseCode in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
+            if (!text.trim().startsWith("[")) break
             val arr = JSONArray(text)
             if (arr.length() == 0) break
             for (i in 0 until arr.length()) {
@@ -495,7 +499,9 @@ object ApiClient {
             val url = URL(uri.toString())
             val conn = url.openConnection() as HttpURLConnection
             conn.requestMethod = "GET"
-            val text = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+            val stream = if (conn.responseCode in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
+            if (!text.trim().startsWith("[")) break
             val arr = JSONArray(text)
             if (arr.length() == 0) break
             for (i in 0 until arr.length()) {


### PR DESCRIPTION
## Summary
- handle empty/non-array responses in `fetchAll*` methods

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687674e066e08329b6a08a76df021adc