### PR TITLE
Implement master refresh for 60‑day sync

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseDao.kt
@@ -18,4 +18,7 @@ interface GlucoseDao {
 
     @Query("SELECT date FROM glucose_entries ORDER BY date ASC LIMIT 1")
     suspend fun getEarliestTimestamp(): Long?
+
+    @Query("DELETE FROM glucose_entries")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/GlucoseStorage.kt
@@ -16,6 +16,14 @@ object GlucoseStorage {
         db(context).glucoseDao().insertAll(entries)
     }
 
+    suspend fun replaceAll(context: Context, entries: List<GlucoseEntry>) {
+        val dao = db(context).glucoseDao()
+        dao.deleteAll()
+        if (entries.isNotEmpty()) {
+            dao.insertAll(entries)
+        }
+    }
+
     suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).glucoseDao().getLatestTimestamp()
     }

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionDao.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionDao.kt
@@ -18,4 +18,7 @@ interface InsulinInjectionDao {
 
     @Query("SELECT time FROM insulin_injections ORDER BY time DESC LIMIT 1")
     suspend fun getLatestTimestamp(): Long?
+
+    @Query("DELETE FROM insulin_injections")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionStorage.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/InsulinInjectionStorage.kt
@@ -16,6 +16,15 @@ object InsulinInjectionStorage {
         }
     }
 
+    suspend fun replaceAll(context: Context, injections: List<InsulinInjection>) {
+        val dao = db(context).insulinDao()
+        dao.deleteAll()
+        val entities = injections.map { InsulinInjectionEntity.from(it) }
+        if (entities.isNotEmpty()) {
+            dao.insertAll(entities)
+        }
+    }
+
     suspend fun getLatestTimestamp(context: Context): Long? {
         return db(context).insulinDao().getLatestTimestamp()
     }

--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -145,6 +145,16 @@ class MainActivity : AppCompatActivity() {
             }
         }
         binding.refreshMealsButton.setOnClickListener { loadTreatments() }
+        binding.masterRefreshButton.setOnClickListener {
+            ApiClient.masterRefresh(this) {
+                runOnUiThread {
+                    loadTreatments()
+                    loadInsulinTreatments()
+                    loadInsulinUsage()
+                    loadStats()
+                }
+            }
+        }
         binding.refreshInsulinButton.setOnClickListener { loadInsulinTreatments() }
         binding.refreshInsulinUsageButton.setOnClickListener { loadInsulinUsage() }
         binding.refreshStatsButton.setOnClickListener { loadStats() }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -198,6 +198,12 @@
             android:layout_height="wrap_content"
             android:text="@string/refresh" />
 
+        <Button
+            android:id="@+id/masterRefreshButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/master_refresh" />
+
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="hba1c_days_format">Using last %1$d days of data</string>
     <string name="sd_format">SD: %.1f mmol/L</string>
     <string name="refresh">Refresh</string>
+    <string name="master_refresh">Master Refresh</string>
 </resources>


### PR DESCRIPTION
## Summary
- add DAO methods and storage helpers for replacing data
- fetch 60 days of treatments, insulin and glucose in `ApiClient`
- wire up new master refresh button in Meals tab
- include new string resource

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768050ca1883298427c0856a9357a9