### PR TITLE
Add column headings for insulin usage page

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -248,6 +248,62 @@
         android:layout_weight="1"
         android:visibility="gone">
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="8dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/insulin_usage_heading_date"
+                android:textStyle="bold"
+                android:gravity="center_horizontal" />
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/insulin_usage_heading_novorapid"
+                android:textStyle="bold"
+                android:gravity="center_horizontal" />
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/insulin_usage_heading_tresiba"
+                android:textStyle="bold"
+                android:gravity="center_horizontal" />
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/insulin_usage_heading_carbs"
+                android:textStyle="bold"
+                android:gravity="center_horizontal" />
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/insulin_usage_heading_protein"
+                android:textStyle="bold"
+                android:gravity="center_horizontal" />
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/insulin_usage_heading_fat"
+                android:textStyle="bold"
+                android:gravity="center_horizontal" />
+
+        </LinearLayout>
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/insulinUsageRecyclerView"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,10 @@
     <string name="sd_format">SD: %.1f mmol/L</string>
     <string name="refresh">Refresh</string>
     <string name="master_refresh">Master Refresh</string>
+    <string name="insulin_usage_heading_date">Date</string>
+    <string name="insulin_usage_heading_novorapid">Novorapid</string>
+    <string name="insulin_usage_heading_tresiba">Tresiba</string>
+    <string name="insulin_usage_heading_carbs">Carbs</string>
+    <string name="insulin_usage_heading_protein">Protein</string>
+    <string name="insulin_usage_heading_fat">Fat</string>
 </resources>


### PR DESCRIPTION
## Summary
- add string resources for insulin usage column headers
- display header row with column names above the insulin usage list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768da99b1c8329bf960b207591cdf7