### PR TITLE
Add meal log confirmation

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,6 @@
     <string name="insulin_usage_heading_carbs">Carbs</string>
     <string name="insulin_usage_heading_protein">Protein</string>
     <string name="insulin_usage_heading_fat">Fat</string>
+    <string name="meal_logged_title">Meal Logged</string>
+    <string name="meal_logged_message">Carbs: %1$.1fg\nProtein: %2$.1fg\nFat: %3$.1fg\nNote: %4$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- show confirmation dialog when a meal is logged
- allow `loadTreatments` to accept callback
- add strings for confirmation dialog

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cbd0447083298feb815e46671480