### PR TITLE
Ensure meal list scrolls to newest item

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -224,6 +224,9 @@ class MainActivity : AppCompatActivity() {
                 result?.let { treatments ->
                     Log.d(TAG, "Received ${treatments.size} treatments")
                     adapter.submitList(treatments)
+                    if (treatments.isNotEmpty()) {
+                        binding.treatmentsRecyclerView.scrollToPosition(0)
+                    }
                     onComplete?.invoke(treatments)
                 } ?: run {
                     Log.e(TAG, "Failed to load treatments")


### PR DESCRIPTION
## Summary
- auto-scroll `treatmentsRecyclerView` to top when meal data is refreshed

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf5809a88329af5b77cf318e4f40