### PR TITLE
Update sendTreatment to persist API result

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/ApiClient.kt
@@ -109,7 +109,22 @@ object ApiClient {
                     os.write(treatment.toJson().toString().toByteArray())
                 }
 
-                val success = conn.responseCode in 200..299
+                var success = conn.responseCode in 200..299
+                if (success) {
+                    try {
+                        val body = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+                        val arr = JSONArray(body)
+                        if (arr.length() > 0) {
+                            val saved = Treatment.fromJson(arr.getJSONObject(0))
+                            TreatmentStorage.addOrUpdate(context, listOf(saved))
+                        } else {
+                            success = false
+                        }
+                    } catch (_: Exception) {
+                        success = false
+                    }
+                }
+
                 withContext(Dispatchers.Main) {
                     callback(success)
                 }


### PR DESCRIPTION
## Summary
- store treatment returned by Nightscout in local storage

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e7df0080832990ea75ccc20458f3