### PR TITLE
Fix highlight logic for new treatments

### DIFF
--- a/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
+++ b/app/src/main/java/com/atelierdjames/nillafood/MainActivity.kt
@@ -245,12 +245,12 @@ class MainActivity : AppCompatActivity() {
                         val newItems = if (lastTreatmentTimestamp != null) {
                             updated.filter { it.timestamp > lastTreatmentTimestamp!! }
                         } else {
-                            updated
+                            emptyList()
                         }
                         if (newItems.isNotEmpty()) {
                             adapter.markNewItems(newItems)
                         }
-                        lastTreatmentTimestamp = newFirst
+                        lastTreatmentTimestamp = newFirst ?: lastTreatmentTimestamp
                         onComplete?.invoke(updated)
                     }
                 }


### PR DESCRIPTION
## Summary
- don't highlight all treatments when app starts

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877566720788329812b2acb40a2d62b